### PR TITLE
Make syntax example more complicated

### DIFF
--- a/test/files/syntax.bib
+++ b/test/files/syntax.bib
@@ -6,13 +6,13 @@ preamble
   %a
 { "Maintained by " # maintainer }
 
-@String(stefan = "Stefan Swe{\\i}g")
+@String(Stefan = "Stefan Swe{\\i}g")
 @String(and = " and ")
 
 @Book{sweig42,
   Author =	 stefan # and # maintainer,
   title =	 { The {impossible} TEL---book },
   publisher =	 { D\\"ead Po$_{eee}$t Society},
-  year =	 1942,
+  yEAr =	 1942,
   month =        mar
 }

--- a/test/files/syntax.bib
+++ b/test/files/syntax.bib
@@ -1,16 +1,16 @@
-@String {maintainer = "Xavier D\\'ecoret"}
+@String {meta:maintainer = "Xavier D\\'ecoret"}
 
 @
   %a
 preamble
   %a
-{ "Maintained by " # maintainer }
+{ "Maintained by " # meta:maintainer }
 
 @String(Stefan = "Stefan Swe{\\i}g")
 @String(and = " and ")
 
 @Book{sweig42,
-  Author =	 stefan # and # maintainer,
+  Author =	 stefan # and # meta:maintainer,
   title =	 { The {impossible} TEL---book },
   publisher =	 { D\\"ead Po$_{eee}$t Society},
   yEAr =	 1942,


### PR DESCRIPTION
The tag's name as well as string's name are not case-sensitive.